### PR TITLE
Quote command-line arguments since they sometimes contain spaces.

### DIFF
--- a/src/main/java/org/spongepowered/gradle/vanilla/internal/ProvideMinecraftPlugin.java
+++ b/src/main/java/org/spongepowered/gradle/vanilla/internal/ProvideMinecraftPlugin.java
@@ -307,7 +307,7 @@ public class ProvideMinecraftPlugin implements Plugin<Project> {
                         }
                         ideaRun.moduleRef(project, moduleSet);
                         ideaRun.setJvmArgs(StringUtils.join(run.getAllJvmArgumentProviders(), true));
-                        ideaRun.setProgramParameters(StringUtils.join(run.getAllArgumentProviders(), false));
+                        ideaRun.setProgramParameters(StringUtils.join(run.getAllArgumentProviders(), true));
                     });
                 });
             }


### PR DESCRIPTION
Most noticeable on macOS, where the default assets directory is ~/Library/Application Support/minecraft/assets (which breaks the run configuration).