### PR TITLE
Pull versions for shadowing from 'minecraft' conf

### DIFF
--- a/subprojects/gradle-plugin/src/main/java/org/spongepowered/gradle/vanilla/VanillaGradle.java
+++ b/subprojects/gradle-plugin/src/main/java/org/spongepowered/gradle/vanilla/VanillaGradle.java
@@ -106,7 +106,7 @@ public final class VanillaGradle implements Plugin<Object> {
         });
 
         project.getPlugins().withId("com.github.johnrengelman.shadow", plugin -> {
-            VanillaGradle.applyShadowConfiguration(project.getTasks(), plugin);
+            VanillaGradle.applyShadowConfiguration(project.getTasks(), minecraftConfig.get(), plugin);
         });
 
         this.createDumpClass(project, minecraftConfig);
@@ -178,7 +178,7 @@ public final class VanillaGradle implements Plugin<Object> {
         });
     }
 
-    private static void applyShadowConfiguration(final TaskContainer tasks, final Plugin<?> shadowPlugin) {
+    private static void applyShadowConfiguration(final TaskContainer tasks, final Configuration versionSource, final Plugin<?> shadowPlugin) {
         // Gradle seems to have some sort of classloader isolation................
         // When VanillaGradle is on the root project classpath and also used in
         // subprojects, but the shadow plugin is only applied in subprojects,
@@ -187,7 +187,7 @@ public final class VanillaGradle implements Plugin<Object> {
 
         try {
             Class.forName(VanillaGradle.SHADOW_JAR_TASK_CLASS_NAME);
-            ShadowConfigurationApplier.actuallyApplyShadowConfiguration(tasks);
+            ShadowConfigurationApplier.actuallyApplyShadowConfiguration(tasks, versionSource);
         } catch (final ClassNotFoundException ex) {
             // Isolation
             try (final URLClassLoader classLoader = new SelfPreferringClassLoader(
@@ -195,8 +195,8 @@ public final class VanillaGradle implements Plugin<Object> {
                 shadowPlugin.getClass().getClassLoader()
             )) {
                 Class.forName(ShadowConfigurationApplier.class.getName(), true, classLoader)
-                    .getDeclaredMethod("actuallyApplyShadowConfiguration", TaskContainer.class)
-                    .invoke(null, tasks);
+                    .getDeclaredMethod("actuallyApplyShadowConfiguration", TaskContainer.class, Configuration.class)
+                    .invoke(null, tasks, versionSource);
             } catch (final IOException | ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InvocationTargetException ex2) {
                 throw new GradleException("Failed to configure shadow plugin integration", ex2);
             }

--- a/subprojects/gradle-plugin/src/main/java/org/spongepowered/gradle/vanilla/internal/ResolveMinecraftLibNames.java
+++ b/subprojects/gradle-plugin/src/main/java/org/spongepowered/gradle/vanilla/internal/ResolveMinecraftLibNames.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of VanillaGradle, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package org.spongepowered.gradle.vanilla.internal;
 
 import org.gradle.api.NamedDomainObjectProvider;

--- a/subprojects/gradle-plugin/src/main/java/org/spongepowered/gradle/vanilla/internal/ResolveMinecraftLibNames.java
+++ b/subprojects/gradle-plugin/src/main/java/org/spongepowered/gradle/vanilla/internal/ResolveMinecraftLibNames.java
@@ -1,0 +1,41 @@
+package org.spongepowered.gradle.vanilla.internal;
+
+import org.gradle.api.NamedDomainObjectProvider;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ResolvedConfiguration;
+import org.gradle.api.artifacts.ResolvedDependency;
+
+import java.util.ArrayDeque;
+import java.util.HashSet;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.Callable;
+
+/**
+ * Resolves the names of the Minecraft libraries, for use with the Shadow plugin.
+ */
+public class ResolveMinecraftLibNames implements Callable<Set<String>> {
+    private final NamedDomainObjectProvider<Configuration> minecraftConfig;
+    private Set<String> result;
+
+    public ResolveMinecraftLibNames(NamedDomainObjectProvider<Configuration> minecraftConfig) {
+        this.minecraftConfig = minecraftConfig;
+    }
+
+    @Override
+    public Set<String> call() {
+        if (this.result == null) {
+            final ResolvedConfiguration conf = minecraftConfig.get().getResolvedConfiguration();
+            conf.rethrowFailure();
+            this.result = new HashSet<>();
+            final Queue<ResolvedDependency> deps = new ArrayDeque<>(conf.getFirstLevelModuleDependencies());
+            ResolvedDependency pointer;
+            while ((pointer = deps.poll()) != null) {
+                if (this.result.add(pointer.getName())) {
+                    deps.addAll(pointer.getChildren());
+                }
+            }
+        }
+        return result;
+    }
+}

--- a/subprojects/gradle-plugin/src/shadow/java/org/spongepowered/gradle/vanilla/internal/ShadowConfigurationApplier.java
+++ b/subprojects/gradle-plugin/src/shadow/java/org/spongepowered/gradle/vanilla/internal/ShadowConfigurationApplier.java
@@ -26,6 +26,8 @@ package org.spongepowered.gradle.vanilla.internal;
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar;
 import org.gradle.api.Action;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ResolvedConfiguration;
 import org.gradle.api.artifacts.ResolvedDependency;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.TaskContainer;
@@ -40,7 +42,7 @@ public final class ShadowConfigurationApplier {
     private ShadowConfigurationApplier() {
     }
 
-    public static void actuallyApplyShadowConfiguration(final TaskContainer tasks) {
+    public static void actuallyApplyShadowConfiguration(final TaskContainer tasks, final Configuration versionSource) {
         // Exclude anything in MC or its dependencies from being shadowed
 
         // because the configureEach action is only executed later but we close
@@ -51,33 +53,39 @@ public final class ShadowConfigurationApplier {
         tasks.withType(ShadowJar.class).configureEach(new Action<ShadowJar>() {
             @Override
             public void execute(final ShadowJar task) {
-                task.dependencies(filter -> filter.exclude(new MinecraftExclusionFilter()));
+                task.dependencies(filter -> filter.exclude(new MinecraftExclusionFilter(versionSource)));
             }
         });
     }
 
     static class MinecraftExclusionFilter implements Spec<ResolvedDependency> {
         private final Set<String> minecraftNames = new HashSet<>();
+        private Configuration versionSource;
+
+        public MinecraftExclusionFilter(Configuration versionSource) {
+            this.versionSource = versionSource;
+        }
 
         @Override
         public boolean isSatisfiedBy(final ResolvedDependency dep) {
-            if (this.minecraftNames.contains(dep.getName())) {
-                return true;
-            } else if (dep.getModuleGroup().equals("net.minecraft")) {
-                // Populate the set of excluded dependencies
-                final Queue<ResolvedDependency> deps = new ArrayDeque<>();
-                deps.add(dep);
-                ResolvedDependency pointer;
-                while ((pointer = deps.poll()) != null) {
-                    if (this.minecraftNames.add(pointer.getName())) {
-                        deps.addAll(pointer.getChildren());
-                    }
-                }
-                return true;
+            if (versionSource != null) {
+                resolveVersions();
+                // Don't repeat this later.
+                versionSource = null;
             }
+            return this.minecraftNames.contains(dep.getName());
+        }
 
-            // Anything else: probably fine
-            return false;
+        private void resolveVersions() {
+            final ResolvedConfiguration conf = versionSource.getResolvedConfiguration();
+            conf.rethrowFailure();
+            final Queue<ResolvedDependency> deps = new ArrayDeque<>(conf.getFirstLevelModuleDependencies());
+            ResolvedDependency pointer;
+            while ((pointer = deps.poll()) != null) {
+                if (this.minecraftNames.add(pointer.getName())) {
+                    deps.addAll(pointer.getChildren());
+                }
+            }
         }
     }
 


### PR DESCRIPTION
This prevents constraints from user configurations from affecting the versions used to exclude from shadowing.