### PR TITLE
perf(gradle-plugin): Avoid running asset/native downloads when unnecessary

### DIFF
--- a/subprojects/gradle-plugin/src/main/java/org/spongepowered/gradle/vanilla/VanillaGradle.java
+++ b/subprojects/gradle-plugin/src/main/java/org/spongepowered/gradle/vanilla/VanillaGradle.java
@@ -125,6 +125,7 @@ public final class VanillaGradle implements Plugin<Object> {
 
             this.configureIDEIntegrations(
                 project,
+                minecraft.needsPrepareWorkspace(),
                 p.getTasks().named(Constants.Tasks.PREPARE_WORKSPACE)
             );
         });
@@ -158,6 +159,7 @@ public final class VanillaGradle implements Plugin<Object> {
 
     private void configureIDEIntegrations(
         final Project project,
+        final Provider<Boolean> shouldRunPrepare,
         final TaskProvider<?> prepareWorkspaceTask
     ) {
         project.getPlugins().apply(IdeaExtPlugin.class);
@@ -171,12 +173,16 @@ public final class VanillaGradle implements Plugin<Object> {
                 final TaskTriggersConfig taskTriggers = ((ExtensionAware) ideaExtension).getExtensions().getByType(TaskTriggersConfig.class);
 
                 // Automatically prepare a workspace after importing
-                taskTriggers.afterSync(prepareWorkspaceTask);
+                if (shouldRunPrepare.get()) {
+                    taskTriggers.afterSync(prepareWorkspaceTask);
+                }
             }
 
             @Override
             public void eclipse(final Project project, final EclipseModel eclipse) {
-                eclipse.synchronizationTasks(prepareWorkspaceTask);
+                if (shouldRunPrepare.get()) {
+                    eclipse.synchronizationTasks(prepareWorkspaceTask);
+                }
             }
         });
     }

--- a/subprojects/gradle-plugin/src/main/java/org/spongepowered/gradle/vanilla/internal/MinecraftExtensionImpl.java
+++ b/subprojects/gradle-plugin/src/main/java/org/spongepowered/gradle/vanilla/internal/MinecraftExtensionImpl.java
@@ -35,6 +35,7 @@ import org.gradle.api.invocation.Gradle;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderFactory;
 import org.gradle.util.ConfigureUtil;
 import org.spongepowered.gradle.vanilla.MinecraftExtension;
 import org.spongepowered.gradle.vanilla.internal.model.VersionClassifier;
@@ -44,6 +45,7 @@ import org.spongepowered.gradle.vanilla.internal.repository.MinecraftRepositoryP
 import org.spongepowered.gradle.vanilla.internal.repository.modifier.AccessWidenerModifier;
 import org.spongepowered.gradle.vanilla.internal.repository.modifier.ArtifactModifier;
 import org.spongepowered.gradle.vanilla.repository.MinecraftPlatform;
+import org.spongepowered.gradle.vanilla.repository.MinecraftSide;
 import org.spongepowered.gradle.vanilla.runs.RunConfiguration;
 import org.spongepowered.gradle.vanilla.runs.RunConfigurationContainer;
 
@@ -79,8 +81,10 @@ public class MinecraftExtensionImpl implements MinecraftExtension {
     private final RunConfigurationContainer runConfigurations;
     private volatile Set<ArtifactModifier> lazyModifiers;
 
+    private final Provider<Boolean> needsPrepareWorkspace;
+
     @Inject
-    public MinecraftExtensionImpl(final Gradle gradle, final ObjectFactory factory, final Project project, final Provider<MinecraftProviderService> providerService) {
+    public MinecraftExtensionImpl(final Gradle gradle, final ObjectFactory factory, final ProviderFactory providers, final Project project, final Provider<MinecraftProviderService> providerService) {
         this.project = project;
         this.providerService = providerService;
         this.version = factory.property(String.class);
@@ -129,6 +133,7 @@ public class MinecraftExtensionImpl implements MinecraftExtension {
         this.targetVersion.finalizeValueOnRead();
 
         this.runConfigurations = factory.newInstance(RunConfigurationContainer.class, factory.domainObjectContainer(RunConfiguration.class), this);
+        this.needsPrepareWorkspace = providers.provider(() -> !this.runConfigurations.isEmpty() && this.platform.get().includes(MinecraftSide.CLIENT));
     }
 
     @Override
@@ -268,6 +273,10 @@ public class MinecraftExtensionImpl implements MinecraftExtension {
 
     public Provider<VersionDescriptor.Full> targetVersion() {
         return this.targetVersion;
+    }
+
+    public Provider<Boolean> needsPrepareWorkspace() {
+        return this.needsPrepareWorkspace;
     }
 
 }

--- a/subprojects/gradle-plugin/src/main/java/org/spongepowered/gradle/vanilla/internal/ProvideMinecraftPlugin.java
+++ b/subprojects/gradle-plugin/src/main/java/org/spongepowered/gradle/vanilla/internal/ProvideMinecraftPlugin.java
@@ -137,7 +137,7 @@ public class ProvideMinecraftPlugin implements Plugin<Project> {
             this.configureRepositories(minecraft, p.getRepositories());
 
             prepareWorkspace.configure(task -> {
-                if (minecraft.platform().get().includes(MinecraftSide.CLIENT)) {
+                if (minecraft.needsPrepareWorkspace().get()) {
                     task.dependsOn(assets);
                 }
             });


### PR DESCRIPTION
Assets are only needed for actually running the game. In submodules with no run configs, we can skip these steps in order to improve the speed of project import.

(this is completely untested btw)

See #102