### PR TITLE
Remove deprecated forUseAtConfigurationTime call

### DIFF
--- a/subprojects/gradle-plugin/src/main/java/org/spongepowered/gradle/vanilla/internal/repository/MinecraftRepositoryPlugin.java
+++ b/subprojects/gradle-plugin/src/main/java/org/spongepowered/gradle/vanilla/internal/repository/MinecraftRepositoryPlugin.java
@@ -303,7 +303,6 @@ public class MinecraftRepositoryPlugin implements Plugin<Object> {
         final File root
     ) {
         return providers.gradleProperty(propertyName)
-            .forUseAtConfigurationTime()
             .map(dirName -> {
                 final File dir = new File(dirName);
                 if (dir.isAbsolute()) {


### PR DESCRIPTION
Has been a no-op since Gradle 7.4, it seems like Gradle has started warning about its use in 8.5. If you prefer a helper that still calls the method on <7.4 let me know and I can add that.