### PR TITLE
Update AccessWidener to 2.1.0, Fix Usage

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 version = "1.0"
 
 [versions]
-accessWidener = "1.1.0"
+accessWidener = "2.1.0"
 asm = "9.6"
 checker = "3.40.0"
 forgeAutoRenamingTool = "1.0.6"

--- a/subprojects/gradle-plugin/src/accessWiden/java/org/spongepowered/gradle/vanilla/internal/worker/AccessWidenerEntryTransformer.java
+++ b/subprojects/gradle-plugin/src/accessWiden/java/org/spongepowered/gradle/vanilla/internal/worker/AccessWidenerEntryTransformer.java
@@ -25,7 +25,7 @@
 package org.spongepowered.gradle.vanilla.internal.worker;
 
 import net.fabricmc.accesswidener.AccessWidener;
-import net.fabricmc.accesswidener.AccessWidenerVisitor;
+import net.fabricmc.accesswidener.AccessWidenerClassVisitor;
 import net.minecraftforge.fart.api.Transformer;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
@@ -46,7 +46,7 @@ final class AccessWidenerEntryTransformer implements Transformer {
         final ClassReader reader = new ClassReader(entry.getData());
         final ClassWriter writer = new ClassWriter(reader, 0);
         // TODO: Expose the ASM version constant somewhere visible to this worker
-        final ClassVisitor visitor = AccessWidenerVisitor.createClassVisitor(Opcodes.ASM9, writer, this.widener);
+        final ClassVisitor visitor = AccessWidenerClassVisitor.createClassVisitor(Opcodes.ASM9, writer, this.widener);
         reader.accept(visitor, 0);
         if (entry.isMultiRelease()) {
             return ClassEntry.create(entry.getName(), entry.getTime(), writer.toByteArray(), entry.getVersion());


### PR DESCRIPTION
Updates Fabric AccessWidener to V2.1.0 and fixes the Breaking change with that update.
Would suggest bumping version number with this but it should be backwards compatible with v1 from the developer side