### PR TITLE
Update AutoRenamingTool, use neoforged version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ version = "1.0"
 accessWidener = "2.1.0"
 asm = "9.7"
 checker = "3.42.0"
-forgeAutoRenamingTool = "1.0.6"
+autoRenamingTool = "2.0.0"
 vineFlower = "1.9.3"
 ideaExt = "1.1.8"
 immutables = "2.10.1"
@@ -26,7 +26,7 @@ accessWidener = { module = "net.fabricmc:access-widener", version.ref = "accessW
 asm = { module = "org.ow2.asm:asm", version.ref = "asm" }
 asm-commons = { module = "org.ow2.asm:asm-commons", version.ref = "asm" }
 asm-util = { module = "org.ow2.asm:asm-util", version.ref = "asm" }
-forgeAutoRenamingTool = { module = "net.minecraftforge:ForgeAutoRenamingTool", version.ref = "forgeAutoRenamingTool" }
+autoRenamingTool = { module = "net.neoforged:AutoRenamingTool", version.ref = "autoRenamingTool" }
 vineFlower = { module = "org.vineflower:vineflower", version.ref = "vineFlower" }
 gson = { module = "com.google.code.gson:gson", version = "2.10.1" }
 ideaExt = { module = "gradle.plugin.org.jetbrains.gradle.plugin.idea-ext:gradle-idea-ext", version.ref = "ideaExt" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,6 +3,9 @@ pluginManagement {
         maven("https://repo.spongepowered.org/repository/maven-public/") {
             name = "sponge"
         }
+        maven("https://maven.neoforged.net/") {
+            name = "neoforged"
+        }
     }
 }
 

--- a/subprojects/gradle-plugin/build.gradle.kts
+++ b/subprojects/gradle-plugin/build.gradle.kts
@@ -34,7 +34,7 @@ val accessWidenerVersion: String by project
 val asmVersion: String by project
 val checkerVersion: String by project
 val vineFlowerVersion: String by project
-val forgeAutoRenamingToolVersion: String by project
+val autoRenamingToolVersion: String by project
 val junitVersion: String by project
 val mergeToolVersion: String by project
 dependencies {
@@ -43,7 +43,7 @@ dependencies {
     commonDeps(libs.asm)
     commonDeps(libs.asm.commons)
     commonDeps(libs.asm.util)
-    commonDeps(libs.forgeAutoRenamingTool) {
+    commonDeps(libs.autoRenamingTool) {
         exclude("org.ow2.asm") // Use our own ASM
         exclude("net.sf.jopt-simple")
     }

--- a/subprojects/gradle-plugin/src/accessWiden/java/org/spongepowered/gradle/vanilla/internal/worker/AccessWidenerEntryTransformer.java
+++ b/subprojects/gradle-plugin/src/accessWiden/java/org/spongepowered/gradle/vanilla/internal/worker/AccessWidenerEntryTransformer.java
@@ -26,8 +26,7 @@ package org.spongepowered.gradle.vanilla.internal.worker;
 
 import net.fabricmc.accesswidener.AccessWidener;
 import net.fabricmc.accesswidener.AccessWidenerClassVisitor;
-import net.fabricmc.accesswidener.AccessWidenerVisitor;
-import net.minecraftforge.fart.api.Transformer;
+import net.neoforged.art.api.Transformer;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;

--- a/subprojects/gradle-plugin/src/accessWiden/java/org/spongepowered/gradle/vanilla/internal/worker/AccessWidenerTransformerProvider.java
+++ b/subprojects/gradle-plugin/src/accessWiden/java/org/spongepowered/gradle/vanilla/internal/worker/AccessWidenerTransformerProvider.java
@@ -26,7 +26,7 @@ package org.spongepowered.gradle.vanilla.internal.worker;
 
 import net.fabricmc.accesswidener.AccessWidener;
 import net.fabricmc.accesswidener.AccessWidenerReader;
-import net.minecraftforge.fart.api.Transformer;
+import net.neoforged.art.api.Transformer;
 import org.gradle.api.GradleException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/subprojects/gradle-plugin/src/main/java/org/spongepowered/gradle/vanilla/internal/repository/modifier/AccessWidenerModifier.java
+++ b/subprojects/gradle-plugin/src/main/java/org/spongepowered/gradle/vanilla/internal/repository/modifier/AccessWidenerModifier.java
@@ -24,7 +24,7 @@
  */
 package org.spongepowered.gradle.vanilla.internal.repository.modifier;
 
-import net.minecraftforge.fart.api.Transformer;
+import net.neoforged.art.api.Transformer;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.gradle.vanilla.internal.repository.ResolvableTool;

--- a/subprojects/gradle-plugin/src/main/java/org/spongepowered/gradle/vanilla/internal/repository/modifier/ArtifactModifier.java
+++ b/subprojects/gradle-plugin/src/main/java/org/spongepowered/gradle/vanilla/internal/repository/modifier/ArtifactModifier.java
@@ -24,8 +24,8 @@
  */
 package org.spongepowered.gradle.vanilla.internal.repository.modifier;
 
-import net.minecraftforge.fart.api.Renamer;
-import net.minecraftforge.fart.api.Transformer;
+import net.neoforged.art.api.Renamer;
+import net.neoforged.art.api.Transformer;
 import org.spongepowered.gradle.vanilla.repository.MinecraftResolver;
 
 import java.io.IOException;

--- a/subprojects/gradle-plugin/src/main/java/org/spongepowered/gradle/vanilla/internal/transformer/FilterClassesTransformer.java
+++ b/subprojects/gradle-plugin/src/main/java/org/spongepowered/gradle/vanilla/internal/transformer/FilterClassesTransformer.java
@@ -24,7 +24,7 @@
  */
 package org.spongepowered.gradle.vanilla.internal.transformer;
 
-import net.minecraftforge.fart.api.Transformer;
+import net.neoforged.art.api.Transformer;
 
 import java.util.Set;
 

--- a/subprojects/gradle-plugin/src/main/java/org/spongepowered/gradle/vanilla/internal/transformer/LocalVariableNameFixer.java
+++ b/subprojects/gradle-plugin/src/main/java/org/spongepowered/gradle/vanilla/internal/transformer/LocalVariableNameFixer.java
@@ -24,7 +24,7 @@
  */
 package org.spongepowered.gradle.vanilla.internal.transformer;
 
-import net.minecraftforge.fart.api.Transformer;
+import net.neoforged.art.api.Transformer;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
 import org.spongepowered.gradle.vanilla.internal.asm.LocalVariableNamingClassVisitor;

--- a/subprojects/gradle-plugin/src/main/java/org/spongepowered/gradle/vanilla/internal/transformer/RecordSignatureFixer.java
+++ b/subprojects/gradle-plugin/src/main/java/org/spongepowered/gradle/vanilla/internal/transformer/RecordSignatureFixer.java
@@ -24,8 +24,8 @@
  */
 package org.spongepowered.gradle.vanilla.internal.transformer;
 
-import net.minecraftforge.fart.api.ClassProvider;
-import net.minecraftforge.fart.api.Transformer;
+import net.neoforged.art.api.ClassProvider;
+import net.neoforged.art.api.Transformer;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;

--- a/subprojects/gradle-plugin/src/main/java/org/spongepowered/gradle/vanilla/internal/transformer/Transformers.java
+++ b/subprojects/gradle-plugin/src/main/java/org/spongepowered/gradle/vanilla/internal/transformer/Transformers.java
@@ -24,7 +24,7 @@
  */
 package org.spongepowered.gradle.vanilla.internal.transformer;
 
-import net.minecraftforge.fart.api.Transformer;
+import net.neoforged.art.api.Transformer;
 
 import java.util.Set;
 

--- a/subprojects/gradle-plugin/src/main/java/org/spongepowered/gradle/vanilla/repository/MinecraftResolverImpl.java
+++ b/subprojects/gradle-plugin/src/main/java/org/spongepowered/gradle/vanilla/repository/MinecraftResolverImpl.java
@@ -24,11 +24,11 @@
  */
 package org.spongepowered.gradle.vanilla.repository;
 
-import net.minecraftforge.fart.api.Renamer;
-import net.minecraftforge.fart.api.SignatureStripperConfig;
-import net.minecraftforge.fart.api.SourceFixerConfig;
-import net.minecraftforge.fart.api.Transformer;
-import net.minecraftforge.srgutils.IMappingFile;
+import net.neoforged.art.api.Renamer;
+import net.neoforged.art.api.SignatureStripperConfig;
+import net.neoforged.art.api.SourceFixerConfig;
+import net.neoforged.art.api.Transformer;
+import net.neoforged.srgutils.IMappingFile;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.gradle.api.GradleException;
 import org.immutables.value.Value;


### PR DESCRIPTION
This migrates to [neoforged's version of AutoRenamingTool](https://github.com/neoforged/AutoRenamingTool). Where Forge's version hasn't really had many changes in a long time, this takes off a solid 15 seconds of the 1 minute and 30-ish second total I get on a Windows machine for a full decompile of joined Minecraft code