### PR TITLE
Execute Idea synchronization task in the current Gradle execution

### DIFF
--- a/subprojects/gradle-plugin/src/main/java/org/spongepowered/gradle/vanilla/internal/ide/EclipseIntegration.java
+++ b/subprojects/gradle-plugin/src/main/java/org/spongepowered/gradle/vanilla/internal/ide/EclipseIntegration.java
@@ -1,0 +1,65 @@
+/*
+ * This file is part of VanillaGradle, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) SpongePowered <https://www.spongepowered.org>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.gradle.vanilla.internal.ide;
+
+import org.gradle.api.Project;
+import org.gradle.api.tasks.TaskProvider;
+import org.gradle.plugins.ide.eclipse.EclipsePlugin;
+import org.gradle.plugins.ide.eclipse.model.EclipseModel;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+public final class EclipseIntegration {
+
+    /**
+     * Applies the specified configuration action to configure Eclipse projects.
+     *
+     * <p>This does not apply the Eclipse plugin, but will perform the action when the plugin is applied.</p>
+     *
+     * @param project project to apply to
+     * @param action the action to perform
+     */
+    public static void apply(final Project project, final Consumer<EclipseModel> action) {
+        project.getPlugins().withType(EclipsePlugin.class, plugin -> {
+            final EclipseModel model = project.getExtensions().findByType(EclipseModel.class);
+            if (model == null) {
+                return;
+            }
+            action.accept(model);
+        });
+    }
+
+    /**
+     * Executes a task when Eclipse performs a project synchronization.
+     *
+     * @param project project of the task
+     * @param supplier supplier that may provide a task
+     */
+    public static void addSynchronizationTask(final Project project, final Supplier<Optional<TaskProvider<?>>> supplier) {
+        EclipseIntegration.apply(project, (eclipseModel -> supplier.get().ifPresent(eclipseModel::synchronizationTasks)));
+    }
+}


### PR DESCRIPTION
Registering an afterSync task via Idea-Ext plugin has two major drawbacks: 
1. It is persistent, even if VanillaGradle or the task have been removed from the Gradle configuration. This can result an error when trying to sync the project.

Example when removing Kyori Blossom (which suffers from the same problem) from SpongeVanilla and then syncing.
<img width="995" height="361" alt="Capture d'écran 2025-10-16 131602" src="https://github.com/user-attachments/assets/3e543beb-f96c-4b30-9e69-c3de3a7142de" />

Persisted tasks are shown in Idea "Tasks Activation" window. Example from Sponge. There, the task must be removed manually to fix the above error.
<img width="391" height="544" alt="Capture d'écran 2025-10-16 103637" src="https://github.com/user-attachments/assets/e2b7a4a6-ab11-476e-8ea4-876dfef44635" />

2. It is slow. To execute the afterSync tasks, Idea starts a second Gradle daemon. The extra JVM and the extra Gradle configuration phases slow down the project sync.

This can be verified by executing command `jps` (from the JDK) when importing Sponge. A second Gradle daemon appears when Idea starts executing the sync tasks:
<img width="661" height="638" alt="Capture d'écran 2025-10-16 104248" src="https://github.com/user-attachments/assets/dfbacafb-2f5d-4d55-a108-5fc1351a153c" />

```
PS C:\Users\x> jps
x GradleDaemon
x Jps
x Main
x GradleDaemon
```

A better alternative is simply to detect when the current Gradle run is due to an Idea project synchronization and to add the sync task to the start parameters.

This is what has been used for years by some other projects:
- [ModDevGradle](https://github.com/neoforged/ModDevGradle/blob/be887af7b87ae95e978e36da0faef183eca75de2/src/main/java/net/neoforged/moddevgradle/internal/IntelliJIntegration.java#L65)
- [fabric-loom](https://github.com/FabricMC/fabric-loom/blob/d6ff760ca5adf3a92c3597d532002cd011c30603/src/main/java/net/fabricmc/loom/configuration/ide/idea/IdeaConfiguration.java#L57)
- [Sponge](https://github.com/SpongePowered/Sponge/blob/ed272c8dcd50115faf22018cbdd5e0d7021be623/forge/build.gradle.kts#L463)

and yet, no issue has been reported.

I don't have any rigorous performance metrics, but Sponge sync time on my computer goes from ~25s down to ~13s after using the new approach when all tasks are fully cached. As expected, dividing by 2 the number of Gradle daemons, divides by 2 the sync time when we are only running the configuration phases.
