### PR TITLE
Bump target JDK version to 11

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,7 +44,8 @@ subprojects {
         mitLicense()
 
         javaVersions {
-            testWith(8, 11, 17)
+            target(11)
+            testWith(11, 17, 21)
         }
 
         configurePublications {

--- a/subprojects/downloader-apache-http/build.gradle.kts
+++ b/subprojects/downloader-apache-http/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     alias(libs.plugins.indra.publishing)
 }
 
-description = "An implementation of the resolver Downloader based on the JDK 11 HTTP Client"
+description = "An implementation of the resolver Downloader based on the Apache HTTP Client"
 
 dependencies {
     api(project(":vanillagradle-resolver-core"))

--- a/subprojects/downloader-jdk-http/build.gradle.kts
+++ b/subprojects/downloader-jdk-http/build.gradle.kts
@@ -2,13 +2,7 @@ plugins {
     alias(libs.plugins.indra.publishing)
 }
 
-description = "An implementation of the resolver Downloader based on the JDK 11 HTTP Client"
-
-indra {
-    javaVersions {
-        target(11)
-    }
-}
+description = "An implementation of the resolver Downloader based on the JDK HTTP Client"
 
 dependencies {
     api(project(":vanillagradle-resolver-core"))


### PR DESCRIPTION
- Required by #180.
- Will allow removing `downloader-apache-http` in favor of `downloader-jdk-http` in the future.

We will update to JDK 17 or 21 later, likely in 0.3.0. For now I'm trying to minimize the changes for 0.2.2.