### PR TITLE
Remove shadow alternative plugin ids

### DIFF
--- a/subprojects/gradle-plugin/src/main/java/org/spongepowered/gradle/vanilla/VanillaGradle.java
+++ b/subprojects/gradle-plugin/src/main/java/org/spongepowered/gradle/vanilla/VanillaGradle.java
@@ -55,9 +55,6 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -70,11 +67,7 @@ import java.util.stream.Stream;
 public final class VanillaGradle implements Plugin<Object> {
 
     private static final String SHADOW_JAR_TASK_CLASS_NAME = "com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar";
-    private static final List<String> SHADOW_PLUGIN_IDS = Collections.unmodifiableList(Arrays.asList(
-            "com.github.johnrengelman.shadow",
-            "io.github.goooler.shadow",
-            "com.gradleup.shadow"
-    ));
+    private static final String SHADOW_PLUGIN_ID = "com.gradleup.shadow";
     private static final AtomicBoolean VERSION_ANNOUNCED = new AtomicBoolean();
 
     @Override
@@ -104,12 +97,10 @@ public final class VanillaGradle implements Plugin<Object> {
             });
         });
 
-        for (final String shadowPluginId : SHADOW_PLUGIN_IDS) {
-            project.getPlugins().withId(shadowPluginId, plugin -> {
-                final Provider<Set<String>> provider = project.provider(new ResolveMinecraftLibNames(minecraftConfig));
-                VanillaGradle.applyShadowConfiguration(project.getTasks(), provider, plugin);
-            });
-        }
+        project.getPlugins().withId(SHADOW_PLUGIN_ID, plugin -> {
+            final Provider<Set<String>> provider = project.provider(new ResolveMinecraftLibNames(minecraftConfig));
+            VanillaGradle.applyShadowConfiguration(project.getTasks(), provider, plugin);
+        });
 
         this.createDumpClass(project, minecraftConfig);
         this.createDisplayMinecraftVersions(project.getPlugins().getPlugin(MinecraftRepositoryPlugin.class).service(), project.getTasks());


### PR DESCRIPTION
The main shadow fork has introduced breaking changes making it incompatible with the other unmaintained alternatives.